### PR TITLE
ci: npm publish workflow (from GitHub)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,33 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Node.js Package
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
## Overview

Use the GitHub-suggested NPM `publish` workflow _verbatim_.

## Screenshots

<img width="261" alt="github npm publish workflow suggestion" src="https://github.com/user-attachments/assets/7622d8fb-2174-4e36-9d93-9358593240c9" />

## Notes

I clicked [[Configure]](https://github.com/TACC/Core-Components/new/main?filename=.github%2Fworkflows%2Fnpm-publish.yml&workflow_template=ci%2Fnpm-publish) button on a —

> **Suggested workflows**
> Based on your tech stack

— option which then created this file.