### PR TITLE
Remove defaultProps

### DIFF
--- a/src/lib/Checkbox/Checkbox.jsx
+++ b/src/lib/Checkbox/Checkbox.jsx
@@ -8,7 +8,7 @@ import styles from './Checkbox.module.css';
 // RFE: Use (and style) an actual checkbox… `<input type="checkbox">`
 //      and still support `DataFilesListingCells`'s button usage (how?)
 //      (this would also resolve the aria/lint complications noted below)
-const Checkbox = ({ className, isChecked, tabIndex, role, ...props }) => {
+const Checkbox = ({className= '', isChecked= false, tabIndex= 0, role= 'checkbox', ...props }) => {
   const rootStyleNames = [
     styles['root'],
     isChecked ? styles['is-checked'] : '',
@@ -42,12 +42,6 @@ Checkbox.propTypes = {
   tabIndex: PropTypes.number,
   /** Standard HTML attribute [role] */
   role: PropTypes.string,
-};
-Checkbox.defaultProps = {
-  className: '',
-  isChecked: false,
-  tabIndex: 0,
-  role: 'checkbox',
 };
 
 export default Checkbox;

--- a/src/lib/DescriptionList/DescriptionList.jsx
+++ b/src/lib/DescriptionList/DescriptionList.jsx
@@ -18,7 +18,12 @@ export const DENSITY_CLASS_MAP = {
 export const DEFAULT_DENSITY = 'default';
 export const DENSITIES = ['', ...Object.keys(DENSITY_CLASS_MAP)];
 
-const DescriptionList = ({ className, data, density, direction }) => {
+const DescriptionList = ({
+  className = '',
+  data,
+  density = DEFAULT_DENSITY,
+  direction = DEFAULT_DIRECTION,
+ }) => {
   const modifierClasses = [];
   modifierClasses.push(DENSITY_CLASS_MAP[density || DEFAULT_DENSITY]);
   modifierClasses.push(DIRECTION_CLASS_MAP[direction || DEFAULT_DIRECTION]);
@@ -67,11 +72,6 @@ DescriptionList.propTypes = {
   density: PropTypes.oneOf(DENSITIES),
   /** Layout direction */
   direction: PropTypes.oneOf(DIRECTIONS),
-};
-DescriptionList.defaultProps = {
-  className: '',
-  density: DEFAULT_DENSITY,
-  direction: DEFAULT_DIRECTION,
 };
 
 export default DescriptionList;

--- a/src/lib/DropdownSelector/DropdownSelector.jsx
+++ b/src/lib/DropdownSelector/DropdownSelector.jsx
@@ -13,7 +13,7 @@ export const DEFAULT_TYPE = 'single';
 //      - https://www.npmjs.com/package/react-either-property
 //      - "customProp" at https://reactjs.org/docs/typechecking-with-proptypes.html#proptypes
 
-const DropdownSelector = ({ type, onChange, ...props }) => {
+const DropdownSelector = ({ type = DEFAULT_TYPE, onChange = () => null, ...props }) => {
   const canSelectMany = type === 'multiple';
 
   return (
@@ -39,10 +39,6 @@ DropdownSelector.propTypes = {
   /** Options (as children, like Reactstrap) */
   // FAQ: Limiting and documenting this has become a rabbit hole; help welcome — Wes B
   // children: PropTypes.any.isRequired
-};
-DropdownSelector.defaultProps = {
-  type: DEFAULT_TYPE,
-  onChange: () => null,
 };
 
 export default DropdownSelector;

--- a/src/lib/Form/FormField.jsx
+++ b/src/lib/Form/FormField.jsx
@@ -14,7 +14,7 @@ import PropTypes from 'prop-types';
 import './FormField.global.css';
 
 /** A limited-choice wrapper for `FormField` */
-const FormFieldWrapper = ({ children, type }) => {
+const FormFieldWrapper = ({ children, type = 'FormGroup' }) => {
   let wrapper;
 
   switch (type) {
@@ -35,9 +35,6 @@ FormFieldWrapper.propTypes = {
   /** Which wrapper to use */
   type: PropTypes.oneOf(['InputGroup', 'FormGroup', '']),
 };
-FormFieldWrapper.defaultProps = {
-  type: 'FormGroup',
-};
 
 /**
  * A standard form field that supports some customization and presets.
@@ -49,20 +46,21 @@ FormFieldWrapper.defaultProps = {
  * - Agave File Selector (requires `agaveFile` and `SelectModal`)
  */
 const FormField = ({
-  addon,
-  addonType,
-  label,
-  description,
-  required,
-  agaveFile,
-  SelectModal,
+  id = undefined,
+  name,
+  label = undefined,
+  description = undefined,
+  required = false,
+  agaveFile = undefined,
+  SelectModal = undefined,
+  addon = undefined,
+  addonType = undefined,
   ...props
 }) => {
   // useField() returns [formik.getFieldProps(), formik.getFieldMeta()]
   // which we can spread on <input> and also replace ErrorMessage entirely.
   const [field, meta, helpers] = useField(props);
   const [openAgaveFileModal, setOpenAgaveFileModal] = useState(false);
-  const { id, name } = props;
   const hasAddon = addon !== undefined;
   const wrapperType = hasAddon ? 'InputGroup' : '';
 
@@ -142,7 +140,7 @@ const FormField = ({
 };
 FormField.propTypes = {
   id: PropTypes.string,
-  name: PropTypes.string,
+  name: PropTypes.string.isRequired,
   label: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
   description: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
   required: PropTypes.bool,
@@ -152,17 +150,6 @@ FormField.propTypes = {
   addon: PropTypes.node,
   /** The [`<InputGroupAddon>` `addonType`](https://reactstrap.github.io/components/input-group/) to add */
   addonType: PropTypes.oneOf(['prepend', 'append']),
-};
-FormField.defaultProps = {
-  id: undefined,
-  name: undefined,
-  label: undefined,
-  description: undefined,
-  required: false,
-  agaveFile: undefined,
-  SelectModal: undefined,
-  addon: undefined,
-  addonType: undefined,
 };
 
 export default FormField;

--- a/src/lib/HistoryBadge/HistoryBadge.jsx
+++ b/src/lib/HistoryBadge/HistoryBadge.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes, { number } from 'prop-types';
 import styles from './HistoryBadge.module.css';
 
-const HistoryBadge = ({ unread, disabled }) => {
+const HistoryBadge = ({ unread, disabled = false }) => {
   const rootStyle = disabled ? 'root disabled' : 'root';
   if (unread) {
     return (
@@ -16,10 +16,6 @@ const HistoryBadge = ({ unread, disabled }) => {
 HistoryBadge.propTypes = {
   unread: number.isRequired,
   disabled: PropTypes.bool,
-};
-
-HistoryBadge.defaultProps = {
-  disabled: false,
 };
 
 export default HistoryBadge;

--- a/src/lib/InfiniteScrollTable/InfiniteScrollTable.jsx
+++ b/src/lib/InfiniteScrollTable/InfiniteScrollTable.jsx
@@ -49,12 +49,12 @@ InfiniteScrollNoDataRow.propTypes = {
 const InfiniteScrollTable = ({
   tableColumns,
   tableData,
-  onInfiniteScroll,
-  isLoading,
-  className,
-  noDataText,
-  getRowProps,
-  columnMemoProps,
+  onInfiniteScroll = (offset) => null,
+  isLoading = false,
+  className = '',
+  noDataText = '',
+  getRowProps = (row) => null,
+  columnMemoProps = [],
 }) => {
   const columns = React.useMemo(
     () => tableColumns,
@@ -124,14 +124,6 @@ InfiniteScrollTable.propTypes = {
   noDataText: rowContentPropType,
   getRowProps: PropTypes.func,
   columnMemoProps: PropTypes.arrayOf(PropTypes.any),
-};
-InfiniteScrollTable.defaultProps = {
-  onInfiniteScroll: (offset) => null,
-  isLoading: false,
-  className: '',
-  noDataText: '',
-  getRowProps: (row) => null,
-  columnMemoProps: [],
 };
 
 export default InfiniteScrollTable;

--- a/src/lib/Message/Message.jsx
+++ b/src/lib/Message/Message.jsx
@@ -80,15 +80,16 @@ export const DEFAULT_SCOPE = 'inline'; // FAQ: Historical support for default
  * ...
  */
 const Message = ({
-  ariaLabel,
+
+  ariaLabel = 'message',
   children,
-  className,
-  dataTestid,
-  onDismiss,
-  canDismiss,
-  isVisible,
+  className = '',
+  dataTestid = '',
+  onDismiss = () => null,
+  canDismiss = false,
+  isVisible = true,
   tagName,
-  scope,
+  scope = '', // RFE: Require scope; remove this line
   type,
 }) => {
   const typeMap = TYPE_MAP[type];
@@ -191,15 +192,6 @@ Message.propTypes = {
   tagName: PropTypes.string,
   /** Message type or severity */
   type: PropTypes.oneOf(TYPES).isRequired,
-};
-Message.defaultProps = {
-  ariaLabel: 'message',
-  className: '',
-  canDismiss: false,
-  dataTestid: '',
-  isVisible: true,
-  onDismiss: () => null,
-  scope: '', // RFE: Require scope; remove this line
 };
 
 export default Message;

--- a/src/lib/Paginator/Paginator.jsx
+++ b/src/lib/Paginator/Paginator.jsx
@@ -26,7 +26,8 @@ PaginatorPage.propTypes = {
   current: PropTypes.number.isRequired,
 };
 
-const Paginator = ({ pages, current, callback, spread }) => {
+const Paginator = ({ pages, current, callback, spread = 11,
+}) => {
   let start, end;
   if (pages === 1 || pages === 2) {
     end = 0;
@@ -95,10 +96,6 @@ Paginator.propTypes = {
   current: PropTypes.number.isRequired,
   callback: PropTypes.func.isRequired,
   spread: PropTypes.number, // Number of page buttons to show
-};
-
-Paginator.defaultProps = {
-  spread: 11,
 };
 
 export default Paginator;

--- a/src/lib/Pill/Pill.jsx
+++ b/src/lib/Pill/Pill.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 
 import styles from './Pill.module.css';
 
-function Pill({ children, type, className, shouldTruncate }) {
+function Pill({ children, type= 'normal', className= '', shouldTruncate= true, }) {
   let pillStyleName = `${styles['root']} ${styles[`is-${type}`]}`;
 
   if (shouldTruncate) pillStyleName += ` ${styles['should-truncate']}`;
@@ -20,12 +20,6 @@ Pill.propTypes = {
   type: PropTypes.string,
   className: PropTypes.string,
   shouldTruncate: PropTypes.bool,
-};
-
-Pill.defaultProps = {
-  type: 'normal',
-  className: '',
-  shouldTruncate: true,
 };
 
 export default Pill;

--- a/src/lib/Section/Section.jsx
+++ b/src/lib/Section/Section.jsx
@@ -79,19 +79,19 @@ import styles from './Section.module.css';
  * />
  */
 function Section({
-  bodyClassName,
-  children,
-  className,
-  content,
-  contentClassName,
-  contentLayoutName,
-  contentShouldScroll,
-  header,
-  headerActions,
-  headerClassName,
-  manualContent,
-  manualHeader,
-  messages,
+  bodyClassName= '',
+  children= undefined,
+  className= '',
+  content= '',
+  contentClassName= '',
+  contentLayoutName= DEFAULT_LAYOUT,
+  contentShouldScroll= false,
+  header= '',
+  headerActions= '',
+  headerClassName= '',
+  manualContent= undefined,
+  manualHeader= undefined,
+  messages= '',
 }) {
   const shouldBuildHeader = header || headerClassName || headerActions;
 
@@ -179,22 +179,6 @@ Section.propTypes = {
   /** Any message(s) (e.g. <Message>) (but NOT a intro message) */
   messages: PropTypes.node,
 };
-Section.defaultProps = {
-  bodyClassName: '',
-  children: undefined,
-  className: '',
-  content: '',
-  contentClassName: '',
-  contentLayoutName: DEFAULT_LAYOUT,
-  contentShouldScroll: false,
-  header: '',
-  headerActions: '',
-  headerClassName: '',
-  manualContent: undefined,
-  manualHeader: undefined,
-  messages: '',
-  introMessageName: '',
-  introMessageText: '',
-};
+
 
 export default Section;

--- a/src/lib/SectionContent/SectionContent.jsx
+++ b/src/lib/SectionContent/SectionContent.jsx
@@ -52,11 +52,11 @@ export const LAYOUTS = [...Object.keys(LAYOUT_CLASS_MAP)];
  * </SectionContent>
  */
 function SectionContent({
-  className,
+  className = '',
   children,
   layoutName,
-  shouldScroll,
-  tagName,
+  shouldScroll = false,
+  tagName = 'div',
 }) {
   let styleName = '';
   const styleNameList = [styles['root'], layoutStyles['root']];
@@ -82,11 +82,6 @@ SectionContent.propTypes = {
   shouldScroll: PropTypes.bool,
   /** Override tag of the root element */
   tagName: PropTypes.string,
-};
-SectionContent.defaultProps = {
-  className: '',
-  shouldScroll: false,
-  tagName: 'div',
 };
 
 export default SectionContent;

--- a/src/lib/SectionHeader/SectionHeader.jsx
+++ b/src/lib/SectionHeader/SectionHeader.jsx
@@ -36,13 +36,13 @@ import styles from './SectionHeader.module.css';
  * <SectionHeader isForList>Name of List</SectionHeader>
  */
 function SectionHeader({
-  actions,
-  children,
-  className,
-  isForForm,
-  isForTable,
-  isForList,
-  isNestedHeader,
+  actions = '',
+  children = undefined,
+  className = '',
+  isForForm=  false,
+  isForTable = false,
+  isForList = false,
+  isNestedHeader = false,
 }) {
   let styleName = '';
   const styleNameList = [styles['root']];
@@ -80,14 +80,6 @@ SectionHeader.propTypes = {
   isForTable: PropTypes.bool,
   /** Whether this header is for a list */
   isForList: PropTypes.bool,
-};
-SectionHeader.defaultProps = {
-  actions: '',
-  className: '',
-  children: undefined,
-  isForForm: false,
-  isForTable: false,
-  isForList: false,
 };
 
 export default SectionHeader;

--- a/src/lib/SectionMessage/SectionMessage.jsx
+++ b/src/lib/SectionMessage/SectionMessage.jsx
@@ -9,7 +9,7 @@ import Message from '../Message';
  * <SectionMessage type="warning">Uh oh.</SectionMessage>
  * @see _common/Message
  */
-const SectionMessage = (props) => {
+const SectionMessage = ( props ) => {
   const [isVisible, setIsVisible] = useState(true);
   const autoManageVisible = props.canDismiss && props.isVisible === undefined;
   const autoManageDismiss = props.canDismiss && props.onDismiss === undefined;
@@ -41,10 +41,5 @@ const SectionMessage = (props) => {
   return <Message {...messageProps} />;
 };
 SectionMessage.propTypes = Message.propTypes;
-SectionMessage.defaultProps = {
-  ...Message.defaultProps,
-  isVisible: undefined,
-  onDismiss: undefined,
-};
 
 export default SectionMessage;

--- a/src/lib/SectionTableWrapper/SectionTableWrapper.jsx
+++ b/src/lib/SectionTableWrapper/SectionTableWrapper.jsx
@@ -81,18 +81,18 @@ import styles from './SectionTableWrapper.module.css';
  * </SectionTableWrapper>
  */
 function SectionTableWrapper({
-  className,
-  children,
-  content,
-  contentClassName,
-  contentShouldScroll,
-  header,
-  headerActions,
-  headerClassName,
-  manualContent,
-  manualHeader,
-  tagName,
-  isFlexItem,
+  className= '',
+  children= undefined,
+  content= '',
+  contentClassName= '',
+  contentShouldScroll= false,
+  header= '',
+  headerActions= '',
+  headerClassName= '',
+  manualContent= undefined,
+  manualHeader= undefined,
+  tagName= 'article',
+  isFlexItem= false,
 }) {
   let styleName = '';
   const styleNameList = [styles['root']];
@@ -180,20 +180,6 @@ SectionTableWrapper.propTypes = {
   /** Override tag of the root element */
   tagName: PropTypes.string,
   isFlexItem: PropTypes.bool,
-};
-SectionTableWrapper.defaultProps = {
-  children: undefined,
-  className: '',
-  content: '',
-  contentClassName: '',
-  contentShouldScroll: false,
-  header: '',
-  headerActions: '',
-  headerClassName: '',
-  manualHeader: undefined,
-  manualContent: undefined,
-  tagName: 'article',
-  isFlexItem: false,
 };
 
 export default SectionTableWrapper;

--- a/src/lib/ShowMore/ShowMore.jsx
+++ b/src/lib/ShowMore/ShowMore.jsx
@@ -7,7 +7,7 @@ import Button from '../Button';
 
 import styles from './ShowMore.module.css';
 
-const ShowMore = ({ className, children }) => {
+const ShowMore = ({ className='', children }) => {
   const [expanded, setExpanded] = useState(false);
 
   const toggleCallback = useCallback(() => {
@@ -43,10 +43,6 @@ const ShowMore = ({ className, children }) => {
 ShowMore.propTypes = {
   className: PropTypes.string,
   children: PropTypes.node.isRequired,
-};
-
-ShowMore.defaultProps = {
-  className: '',
 };
 
 export default ShowMore;

--- a/src/lib/Sidebar/Sidebar.jsx
+++ b/src/lib/Sidebar/Sidebar.jsx
@@ -12,7 +12,7 @@ function isNotEmptyString(props, propName, componentName) {
   return null;
 }
 
-const SidebarItem = ({ to, iconName, label, children, disabled, hidden }) => {
+const SidebarItem = ({ to, iconName, label, children=null, disabled=false, hidden=false }) => {
   return (
     <NavItem>
       <NavLink
@@ -35,15 +35,10 @@ SidebarItem.propTypes = {
   label: isNotEmptyString,
   children: PropTypes.node,
   disabled: PropTypes.bool,
-  hidden: PropTypes.bool,
-};
-SidebarItem.defaultProps = {
-  children: null,
-  disabled: false,
-  hidden: false,
 };
 
-const Sidebar = ({ sidebarItems, addItems, loading }) => {
+
+const Sidebar = ({ sidebarItems, addItems=[], loading=false }) => {
   return (
     <Nav className={styles['root']} vertical>
       {!loading &&
@@ -76,10 +71,6 @@ Sidebar.propTypes = {
   sidebarItems: PropTypes.arrayOf(PropTypes.object).isRequired,
   addItems: PropTypes.arrayOf(PropTypes.object),
   loading: PropTypes.bool,
-};
-Sidebar.defaultProps = {
-  addItems: [],
-  loading: false,
 };
 
 export default Sidebar;


### PR DESCRIPTION
## Overview

Refactor to remove defaultProps as they are being deprecated:

```
Warning: Message: Support for defaultProps will be removed from function components in a future major release. Use JavaScript default parameters instead
```
## Related

[WI-208](https://tacc-main.atlassian.net/browse/WI-208)

<!--
- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
- requires https://github.com/TACC/Core-Styles/pull/5
- required by https://github.com/TACC/Core-CMS-Resources/pull/117
-->…

