### PR TITLE
feat: deploy storybook to gh pages

### DIFF
--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -1,0 +1,22 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
+
+name: Storybook.js Deploy
+-on:
+  push:
+    branches:
+      - "main" # change to the branch you wish to deploy from
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - id: build-publish
+      uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
+      with:
+        path: demo

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -2,7 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Storybook.js Deploy
--on:
+
+on:
   push:
     branches:
       - "main" # change to the branch you wish to deploy from

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -21,4 +21,6 @@ jobs:
       uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
       with:
         path: demo
+        checkout: true
+        install_command: npm ci
         build_command: npm run build-demo

--- a/.github/workflows/storybook-deploy.yml
+++ b/.github/workflows/storybook-deploy.yml
@@ -21,3 +21,4 @@ jobs:
       uses: bitovi/github-actions-storybook-to-github-pages@v1.0.3
       with:
         path: demo
+        build_command: npm run build-demo

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 # Project
 node_modules
 dist
+demo
 
 # IDE
 .vscode

--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Perform manually by installing and testing the components in a separate resposit
 | - | - | - |
 | `npm run start` | start demo | [Storybook](https://storybook.js.org/) |
 | `npm run build` | build components | [Vite](https://vitejs.dev/) |
+| `npm run build-demo` | build demo | [Storybook](https://storybook.js.org/) |
 | `npm run test` | execute unit tests | [Vitest](https://vitest.dev/) |
 
 <!-- Link Aliases -->

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/TACC/Core-Components",
   "scripts": {
     "start": "storybook dev --port 9000",
+    "build-demo": "storybook build --output-dir demo",
     "build": "vite build --outDir dist",
     "// build": "tsc -b && vite build",
     "lint": "eslint .",


### PR DESCRIPTION
## Overview

Deploy Storybook demo & docs to GitHub Pages.

> [!IMPORTANT]
> Merged early so I can actually test workflow.

## Changes

- **adds**
    - workflow
    - command
    - `.gitingore` entry

## Testing

1. `npm build && npx serve demo` builds then serves a demo.
2. After/As this is merged, a commit to `main` updates demo at https://tacc.github.io/Core-Components.