### PR TITLE
feat: ...rest spread to Button for HTML attr passthrough

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,20 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is `@tacc/core-components`, a React component library (TypeScript/JSX) built with Vite and demoed via Storybook. No backend, database, or Docker required.
+
+### Commands
+
+See `README.md` "Resources > Commands" for the full list. Key commands:
+
+- `npm start` — Storybook dev server on port 9000
+- `npm test` — Vitest unit tests (use `npm test -- --run` for single run)
+- `npm run build` — Vite library build to `dist/`
+- `npm run lint` — ESLint (see caveat below)
+
+### Caveats
+
+- **ESLint is not a project dependency.** The `npm run lint` script calls `eslint .` but `eslint` is not listed in `package.json`. The `.eslintrc.json` config is a stub with no parser or plugins, so linting does not currently function. Install eslint@8 globally (`npm install -g eslint@8`) if needed.
+- **Storybook deps are optional.** Always use `npm install --include=optional` to get Storybook packages; plain `npm install` omits them.
+- **Peer dependencies** (React, Formik, Reactstrap, etc.) are resolved from Storybook's transitive deps during development. They are not installed as direct devDependencies.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,15 +6,7 @@ This is `@tacc/core-components`, a React component library (TypeScript/JSX) buil
 
 ### Commands
 
-See `README.md` "Resources > Commands" for the full list. Key commands:
+See `README.md` "Developing" for key commands:
 
-- `npm start` — Storybook dev server on port 9000
-- `npm test` — Vitest unit tests (use `npm test -- --run` for single run)
-- `npm run build` — Vite library build to `dist/`
-- `npm run lint` — ESLint (see caveat below)
-
-### Caveats
-
-- **ESLint is not a project dependency.** The `npm run lint` script calls `eslint .` but `eslint` is not listed in `package.json`. The `.eslintrc.json` config is a stub with no parser or plugins, so linting does not currently function. Install eslint@8 globally (`npm install -g eslint@8`) if needed.
-- **Storybook deps are optional.** Always use `npm install --include=optional` to get Storybook packages; plain `npm install` omits them.
-- **Peer dependencies** (React, Formik, Reactstrap, etc.) are resolved from Storybook's transitive deps during development. They are not installed as direct devDependencies.
+- (if missing dependencies) `npm install --include=optional`
+- `npm start`

--- a/src/lib/Button/Button.stories.tsx
+++ b/src/lib/Button/Button.stories.tsx
@@ -11,6 +11,10 @@ const meta: Meta<typeof Button> = {
       options: Object.keys(SIZE_MAP),
       control: { type: 'inline-radio' },
     },
+    title: {
+      control: 'text',
+      description: 'HTML title attribute (via ...rest)',
+    },
   },
 };
 export default meta;
@@ -40,5 +44,17 @@ export const Types: Story = {
   },
   args: {
     className: styles['button'] + ' ',
+  },
+};
+
+export const HTMLAttributes: Story = {
+  render: (args) => (
+    <Button type="primary" {...args}>
+      Hover me for title tooltip
+    </Button>
+  ),
+  args: {
+    title: 'Hello from rest',
+    'aria-label': 'Example button with HTML attributes',
   },
 };

--- a/src/lib/Button/Button.tsx
+++ b/src/lib/Button/Button.tsx
@@ -44,7 +44,8 @@ type ButtonProps = React.PropsWithChildren<{
   attr?: 'button' | 'submit' | 'reset';
   isLoading?: boolean;
 }> &
-  (ButtonTypeLinkSize | ButtonTypeOtherSize);
+  (ButtonTypeLinkSize | ButtonTypeOtherSize) &
+  Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'type'>;
 
 const Button: React.FC<ButtonProps> = ({
   children,
@@ -59,6 +60,7 @@ const Button: React.FC<ButtonProps> = ({
   onClick,
   attr = 'button',
   isLoading = false,
+  ...rest
 }) => {
   function onclick(e: React.MouseEvent<HTMLButtonElement>) {
     if (disabled) {
@@ -72,6 +74,7 @@ const Button: React.FC<ButtonProps> = ({
 
   return (
     <button
+      {...rest}
       id={id}
       className={`
         ${styles['root']}


### PR DESCRIPTION
## Overview

Support arbitrary HTML attributes on `<Button>` via `...rest` spread.

> [!warning]
> A.I. solution. Works, but I'm not sure whether this is the best way to present it in demo.

## Related

- tested in https://github.com/TACC/tup-ui/pull/537
- mirrors https://github.com/TACC/tup-ui/pull/537/commits/fce6a433

## Changes

- **adds** support for misc HTML attr's
- **adds** `title` attribute to param's
- **adds** Button story to test HTMLA attr's
- _does not break `type` (standard HTML attr for <button>`)_

## Testing

1. …

## Screenshots

…