### PR TITLE
chore: move storybook packages to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "build-demo": "storybook build --output-dir demo",
     "build": "vite build --outDir dist",
     "// build": "tsc -b && vite build",
+    "prepare": "npm run build",
     "lint": "eslint .",
     "test": "vitest"
   },
@@ -36,12 +37,16 @@
     "reactstrap": "^9.1.5"
   },
   "devDependencies": {
+    "@storybook/addon-essentials": "^7.6.19",
+    "@storybook/core-server": "^7.6.19",
+    "@storybook/react-vite": "^7.6.19",
     "@tacc/core-styles": "^2.25.1",
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react-swc": "^3.5.0",
     "jsdom": "^22.1.0",
+    "storybook": "^7.6.19",
     "vite": "^5.0.11",
     "vite-plugin-dts": "^2.3.0",
     "vite-plugin-lib-inject-css": "^2.1.1",
@@ -50,11 +55,5 @@
   },
   "sideEffects": [
     "libs/core-componets/**/*.css"
-  ],
-  "optionalDependencies": {
-    "@storybook/addon-essentials": "^7.6.19",
-    "@storybook/core-server": "^7.6.19",
-    "@storybook/react-vite": "^7.6.19",
-    "storybook": "^7.6.19"
-  }
+  ]
 }


### PR DESCRIPTION
## Overview

1. Move `storybook` packages to devDependencies
2. Adds `prepare` command to support [installing from git repo branch](https://github.com/TACC-Cloud/hazmapper/pull/474/changes/cd116027)

## Related

https://github.com/TACC-Cloud/hazmapper/pull/474


## Notes

Hoping for a new release to pick this up in Hazmapper.