### PR TITLE
fix: add publishConfig and bump version for npm release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@tacc/core-components",
-  "version": "0.0.4",
+  "version": "0.0.5",
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "author": "TACC ACI WMA <wma-portals@tacc.utexas.edu>",
   "contributors": [


### PR DESCRIPTION
## Overview

Two bugs caused the [v0.0.4 release CI run](https://github.com/TACC/Core-Components/actions/runs/29279127039/job/86915954564) to fail:

1. Scoped npm packages default to `--access restricted`, so I add `publishConfig` in `package.json` as `access: public` to let `npm publish` succeeds without extra flags.
2. `0.0.4` was already published to npm, so publishing again would fail with a 403.

## Related

- [failed job](https://github.com/TACC/Core-Components/actions/runs/29279127039/job/86915954564)

## Changes

- **added** `publishConfig.access: "public"` to `package.json`
- **updated** version `0.0.4` → `0.0.5`

## Testing

1. Merge this PR.
2. Create a GitHub release tagged `v0.0.5` (if not already present).
3. Verify the [npm-publish workflow](https://github.com/TACC/Core-Components/actions/workflows/npm-publish.yml) passes and `@tacc/core-components@0.0.5` appears on npm.

## UI

N/A