### PR TITLE
docs: add contributing, publishing, and git message template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,29 +1,65 @@
 ## Overview
 
+<!--
+1–3 sentences stating what problem this solves and what you changed at a high level. Example:
+
+"Fixes caption contrast on dark sections by using opacity instead of a fixed dark color."
+-->
+
 …
 
 ## Related
 
 <!--
-- [FP-123](https://jira.tacc.utexas.edu/browse/FP-123)
-- requires https://github.com/TACC/Core-Styles/pull/5
-- required by https://github.com/TACC/Core-CMS-Resources/pull/117
--->…
+Delete the bullets you don't need. Any ticket / cross-repo links go here. Examples:
+
+- [CMD-XYZ](https://tacc-main.atlassian.net/browse/CMD-XYZ)
+- requires https://github.com/TACC/Core-Styles/pull/NNN
+- required by https://github.com/TACC/Core-CMS/pull/NNN
+-->
+
+- …
 
 ## Changes
 
-…
+<!--
+Use short bullets. Add bold verb as prefix to help scanning; example:
+
+- **added** `LoadingSpinner` component
+- **updated** `Paginator` prop types
+- **deleted** deprecated `Button` variant
+- **fixed** typo
+-->
+
+- …
 
 ## Testing
 
-1.
+<!--
+Numbered steps another dev can repeat. Include local URLs for UI changes. Example:
 
-## Screenshots
+1. `npm start`
+2. Open Storybook at http://localhost:9000
+3. Verify component shows …
+-->
+
+1. 
+
+
+## UI
+
+<!--
+Add screenshots via GitHub PR editor. Organize and label with a table; example:
+
+| Before | After |
+| - | - |
+| <img width="900" alt="before" src="..." /> | <img width="900" alt="after" src="..." /> |
+-->
 
 …
 
 <!--
 ## Notes
 
-…
+Optional: rollout, follow-ups, known limitations, unrelated dist churn.
 -->

--- a/.gitmessage
+++ b/.gitmessage
@@ -1,0 +1,18 @@
+# type(scope)!: short summary
+#
+# Types: feat, fix, docs, style, refactor, perf, test, chore, build, ci
+# Scope (optional): describes area, e.g. api, ui, auth, deps
+# ! (optional): marks breaking changes
+#
+# Examples:
+#   feat(ui)!: add new Paginator component
+#   chore(deps): update
+#   style: delete excess whitespace
+#
+# Body (optional):
+#   what changed (1 sentence)
+#   (if relevant) important decisions/context (succinct bullets)
+#
+# Footer (optional):
+#   BREAKING CHANGE: describe breaking change
+#   Closes #123, Relates-to #456

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# How to Contribute
+
+## Linting and Formatting
+
+Not standardized.
+
+## Best Practices
+
+- [Sign your commits.](https://help.github.com/en/github/authenticating-to-github/managing-commit-signature-verification)
+- [Learn Markdown.](https://github.github.com/gfm/)
+
+## Development Workflow
+
+We use a modified version of [GitFlow](https://datasift.github.io/gitflow/IntroducingGitFlow.html).
+
+- "feature branches" have a specific prefix:
+  - `feat/` for features and updates
+  - `fix/` for bugfixes and hotfixes
+  - `refactor/` for large internal changes
+  - `chore/` for no-op changes
+  - `docs/` for documentation
+  - `perf/` for performance improvements
+  - `test/` for test case updates
+  - or other "types" from [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary)
+- "develop" branch is usually `main`,\
+    <sup>but can exist as a long-lived multi-feature branch prefixed with `dev/`</sup>
+- "release branches" (as needed) are prefixed with `release/`
+- "hotfix branches" are prefixed `fix/`
+- "master branch" is always `main`
+
+## Release Workflow
+
+Follow [PUBLISHING.md](PUBLISHING.md) instructions.

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,0 +1,11 @@
+# How to Publish
+
+Only appointed team members may publish releases.
+
+1. Create new branch for version bump.
+1. Update version via:\
+    `npm version vN.N.N`\
+    (where `N.N.N` is the version tag)
+1. Commit, push, PR, review, merge.
+1. [Create release and tag on GitHub.](https://github.com/TACC/Core-Components/releases/new)\
+    <sub>This triggers CI to build and publish the package to NPM automatically.</sub>

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -1,11 +1,7 @@
 # How to Publish
 
-Only appointed team members may publish releases.
-
-1. Create new branch for version bump.
 1. Update version via:\
     `npm version vN.N.N`\
     (where `N.N.N` is the version tag)
-1. Commit, push, PR, review, merge.
-1. [Create release and tag on GitHub.](https://github.com/TACC/Core-Components/releases/new)\
+2. [Create release and tag on GitHub.](https://github.com/TACC/Core-Components/releases/new)\
     <sub>This triggers CI to build and publish the package to NPM automatically.</sub>

--- a/PUBLISHING.md
+++ b/PUBLISHING.md
@@ -2,6 +2,6 @@
 
 1. Update version via:\
     `npm version vN.N.N`\
-    (where `N.N.N` is the version tag)
+    <sup>(where `N.N.N` is the version tag)</sup>
 2. [Create release and tag on GitHub.](https://github.com/TACC/Core-Components/releases/new)\
-    <sub>This triggers CI to build and publish the package to NPM automatically.</sub>
+    <sup>This triggers CI to build and publish the package to NPM automatically.</sup>


### PR DESCRIPTION
## Overview

Adds contributor documentation and git conventions in the style of Core-CMS and Core-Styles.

> [!WARNING]
> Pending successful release test.

## Related

- `PUBLISHING.md` tested via:
    - #29
    - #_LINK_TO_SECOND_FIX_
    - _LINK_TO_SUCCESSFUL_RUN_

## Changes

- **added** `CONTRIBUTING.md` (which points to PUBLISHING)
- **added** `PUBLISHING.md`
- **added** `.gitmessage`
- **updated** `.github/pull_request_template.md`

## Testing & UI

- [`CONTRIBUTING.md`](https://github.com/TACC/Core-Components/blob/docs/contributing-publishing/CONTRIBUTING.md)
- [`PUBLISHING.md`](https://github.com/TACC/Core-Components/blob/docs/contributing-publishing/PUBLISHING.md)
- [`.gitmessage`](https://github.com/TACC/Core-Components/blob/docs/contributing-publishing/.gitmessage)
- [`.github/pull_request_template.md`](https://github.com/TACC/Core-Components/blob/docs/contributing-publishing/.github/pull_request_template.md?plain=1)