### PR TITLE
feat: allow manual trigger of npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -6,6 +6,7 @@ name: Node.js Package
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
## Overview

Adds `workflow_dispatch` to the npm publish workflow so it can be triggered manually from the GitHub Actions UI, without needing to create a release.

> [!IMPORTANT]
> We would only manually run if it fails and we have a fix after GitHub release, because GitHub release automatically triggers this job.

## Related

- requires https://github.com/TACC/Core-Components/pull/29

## Changes

- **updated** `.github/workflows/npm-publish.yml` — added `workflow_dispatch` trigger

## Testing

1. Merge this PR.
2. Go to [Actions → Node.js Package](https://github.com/TACC/Core-Components/actions/workflows/npm-publish.yml).
3. Click **Run workflow** and confirm it appears as an option.

## UI

N/A