### PR TITLE
ci: publish to npm via Trusted Publisher (OIDC) instead of token

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,4 +1,4 @@
-# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# This workflow will run tests using node and then publish a package to NPM when a release is created
 # For more information see: https://docs.github.com/en/actions/publishing-packages/publishing-nodejs-packages
 
 name: Node.js Package
@@ -6,28 +6,21 @@ name: Node.js Package
 on:
   release:
     types: [created]
+  workflow_dispatch: {}
+
+permissions:
+  id-token: write  # Required for OIDC
 
 jobs:
-  build:
+  publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
-      - run: npm ci
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
+          package-manager-cache: false  # never use caching in release builds
+      - run: npm install
       - run: npm test
-
-  publish-npm:
-    needs: build
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org/
-      - run: npm ci
       - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
     "dist"
   ],
   "homepage": "https://github.com/TACC/Core-Components",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TACC/Core-Components.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TACC/Core-Components/issues"
+  },
   "scripts": {
     "start": "storybook dev --port 9000",
     "build-demo": "storybook build --output-dir demo",


### PR DESCRIPTION
## Overview

Switch npm publishing from a token (`NPM_TOKEN`) to [Trusted Publisher] (OIDC), so CI authenticates to npm without a stored secret. This fixes the publish failure, which was a token auth error.

[Trusted Publisher]: https://docs.npmjs.com/trusted-publishers

## Related

- mirrors [Trusted Publisher] setup used for `@tacc/html-filter-sort`
- follows:
    - #31
    - #29

## Changes

- **changed** npm auth to [Trusted Publisher] (OIDC)
- **removed** the `NPM_TOKEN` secret dependency
- **merged** the build and publish jobs into one
- **updated** workflow actions to `@v6` and Node to `24`

## Testing

> [!TIP]
> [Successfully tested.](https://github.com/TACC/Core-Components/actions/runs/29286986062/job/86941791315)

1. On npmjs.com, register the [Trusted Publisher] for `@tacc/core-components`: owner `TACC`, repo `Core-Components`, workflow `npm-publish.yml`.
2. Publish via a release or `workflow_dispatch`, and confirm it succeeds without a token.

## Notes

> [!TIP]
> [This repo on GitHub is a Trusted Publisher for this NPM package.](https://www.npmjs.com/package/@tacc/core-components/access)